### PR TITLE
Improve grass chunk sampling

### DIFF
--- a/SpaceCamper/Planet/GrassFoliage.h
+++ b/SpaceCamper/Planet/GrassFoliage.h
@@ -30,8 +30,9 @@ public:
 
 private:
 	// Ocahedral 매핑 함수
-	static FVector2D OctahedralEncode(const FVector& N); // Octahedral 맵핑: 구면 좌표계 -> 2D 정사각형
-	static FIntPoint GetChunkCoordFromOctahedral(const FVector& N, int32 NumChunks); // 2D 좌표를 Chunk 인덱스로 변환
+    static FVector2D OctahedralEncode(const FVector& N); // Octahedral 맵핑: 구면 좌표계 -> 2D 정사각형
+    static FVector  OctahedralDecode(const FVector2D& UV); // 2D 정사각형 -> 구면 좌표계
+    static FIntPoint GetChunkCoordFromOctahedral(const FVector& N, int32 NumChunks); // 2D 좌표를 Chunk 인덱스로 변환
 
 	// Chunk 처리 함수
 	void UpdateGrassChunks(const FIntPoint& CenterChunk);


### PR DESCRIPTION
## Summary
- add octahedral decode helper
- sample grass positions using global octahedral coordinates to avoid gaps

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`
- `cargo test` *(fails: could not find `Cargo.toml`)*
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `gradle test` *(fails: directory does not contain a Gradle build)*
- `mvn -q test` *(fails: mvn not found)*
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9c0b84c08333bb123a700b771c07